### PR TITLE
Updated doHelp() & Added Self Tip Detection

### DIFF
--- a/bot/modules/tipbot.js
+++ b/bot/modules/tipbot.js
@@ -102,9 +102,8 @@ function doTip(message, tipper, words) {
     return;
   }
 
-  if (message.mentions.members.first().id) {
-    let member = message.mentions.members.first()
-    sendLbc(message, tipper, member, amount, prv);
+  if (message.mentions.users.first().id) {
+    sendLbc(message, tipper, message.mentions.users.first().id.replace('!', ''), amount, prv);
   }
   else {
     message.reply('Sorry, I could not find a user in your tip...');
@@ -120,8 +119,8 @@ function doHelp(message) {
 }
 
 
-function sendLbc(message, tipper, member, amount, privacyFlag) {
-  getAddress(member.id.replace('!', ''), function (err, address) {
+function sendLbc(message, tipper, recipient, amount, privacyFlag) {
+  getAddress(recipient, function (err, address) {
     if (err) {
       message.reply(err.message);
     }
@@ -132,12 +131,12 @@ function sendLbc(message, tipper, member, amount, privacyFlag) {
         }
         else {
           var imessage =
-            'Wubba lubba dub dub! <@' + tipper + '> tipped <@' + member.id + '> ' + amount + ' LBC (' + txLink(txId) + '). ' +
+            'Wubba lubba dub dub! <@' + tipper + '> tipped <@' + recipient + '> ' + amount + ' LBC (' + txLink(txId) + '). ' +
             'DM me `!tip` for tipbot instructions.'
           if (privacyFlag) {
             message.author.send(imessage);
-            if (message.author.id != member.id) {
-              member.send(imessage);
+            if (message.author.id != message.mentions.users.first().id) {
+              message.mentions.users.first().send(imessage);
             }
           } else {
             message.reply(imessage);

--- a/bot/modules/tipbot.js
+++ b/bot/modules/tipbot.js
@@ -114,11 +114,9 @@ function doTip(message, tipper, words) {
 
 function doHelp(message) {
   if (!inPrivateOrBotSandbox(message)) {
-    message.reply('Please use <#369896313082478594> or DMs to talk to bots.');
-    return;
+    message.reply('Sent you help via DM! Please use <#369896313082478594> or DMs to talk to bots.');
   }
-  message.reply('Sent you help via DM!');
-  message.author.send('**!tip**\n    !tip balance: get your balance\n    !tip deposit: get adress for your deposits\n    !tip withdraw ADDRESS AMOUNT: withdraw AMOUNT credits to ADDRESS\n    !tip <user> <amount>: send <amount> credits to <user>');
+  message.author.send('**!tip**\n    balance: get your balance\n    deposit: get address for your deposits\n    withdraw ADDRESS AMOUNT: withdraw AMOUNT credits to ADDRESS\n    [private] <user> <amount>: mention a user with @ and then the amount to tip them, or put private before the user to tip them privately.\n    Key: [] : Optionally include contained keyword, <> : Replace with appropriate value.');
 }
 
 
@@ -138,7 +136,9 @@ function sendLbc(message, tipper, member, amount, privacyFlag) {
             'DM me `!tip` for tipbot instructions.'
           if (privacyFlag) {
             message.author.send(imessage);
-            member.send(imessage);
+            if (message.author.id != member.id) {
+              member.send(imessage);
+            }
           } else {
             message.reply(imessage);
           }


### PR DESCRIPTION
Updated doHelp() to match updated module description in Commit ec48f11 (https://github.com/lbryio/lbry-tipbot/commit/ec48f114d87feb77e4b6856ca6599659b51f201d#diff-baad512c11a603dedf1cf7f391e341bd)
Also altered help logic so the help message is always DM'd to user to assist new users who struggle to find how to begin a dm session and to improve general usability.

Further added a self tip check to sendLbc() to prevent duplicate messages being received by the user, so as to make clear that the tip is only being sent once.