### PR TITLE
Fixing Duplicate Tipbot Account Issue

### DIFF
--- a/bot/modules/tipbot.js
+++ b/bot/modules/tipbot.js
@@ -102,9 +102,8 @@ function doTip(message, tipper, words) {
     return;
   }
 
-  if (message.mentions.members.first().id) {
-    let member = message.mentions.members.first()
-    sendLbc(message, tipper, member, amount, prv);
+  if (message.mentions.users.first().id) {
+    sendLbc(message, tipper, message.mentions.users.first().id.replace('!', ''), amount, prv);
   }
   else {
     message.reply('Sorry, I could not find a user in your tip...');
@@ -122,8 +121,8 @@ function doHelp(message) {
 }
 
 
-function sendLbc(message, tipper, member, amount, privacyFlag) {
-  getAddress(member.id.replace('!', ''), function (err, address) {
+function sendLbc(message, tipper, recipient, amount, privacyFlag) {
+  getAddress(recipient, function (err, address) {
     if (err) {
       message.reply(err.message);
     }
@@ -134,11 +133,13 @@ function sendLbc(message, tipper, member, amount, privacyFlag) {
         }
         else {
           var imessage =
-            'Wubba lubba dub dub! <@' + tipper + '> tipped <@' + member.id + '> ' + amount + ' LBC (' + txLink(txId) + '). ' +
+            'Wubba lubba dub dub! <@' + tipper + '> tipped <@' + recipient + '> ' + amount + ' LBC (' + txLink(txId) + '). ' +
             'DM me `!tip` for tipbot instructions.'
           if (privacyFlag) {
             message.author.send(imessage);
-            member.send(imessage);
+            if (message.author.id != message.mentions.users.first().id) {
+              message.mentions.users.first().send(imessage);
+            }
           } else {
             message.reply(imessage);
           }


### PR DESCRIPTION
Misunderstood the use of GuildMember in Discord.js due to vague documentation, resulting in tipbot accounts being created accidentally due to getting the wrong Snowflake for the user. The function now takes the user.id of the recipient, preformated to match the tipper, with appropriately adjusted references to the user.

Hopefully this should fix the issues being had though manual recovery of the currency in the accidentally created accounts will still be required. Sorry for the trouble.