### PR TITLE
Fix Private Mode Usernames

### DIFF
--- a/bot/modules/tipbot.js
+++ b/bot/modules/tipbot.js
@@ -315,12 +315,12 @@ function sendLBC(message, tipper, recipient, amount, privacyFlag) {
           let msgtail = `
 DM me with \`${message.content.split(' ', 1)[0]}\` for command specific instructions or with \`!tips\` for all available commands`;
           if (privacyFlag) {
-            let authmsg = `You have just privately tipped <@${recipient}> ${amount} LBC.
+            let usr = message.guild.members.find('id', recipient).user;
+            let authmsg = `You have just privately tipped @${usr.username}#${usr.tag} ${amount} LBC.
 ${tx}${msgtail}`;
             message.author.send(authmsg);
             if (message.author.id !== message.mentions.users.first().id) {
-              let usr = message.guild.members.find('id', recipient).user;
-              let recipientmsg = `You have just been privately tipped ${amount} LBC by <@${tipper}>.
+              let recipientmsg = `You have just been privately tipped ${amount} LBC by @${message.author.username}#${message.author.tag}.
 ${tx}${msgtail}`;
               usr.send(recipientmsg);
             }


### PR DESCRIPTION
So it turns out that if you try to print a userid of someone that isn't in that server, such as in a dm channel, it simply displays as invalid user (Even though userids are unique across the entirety of discord, got to love that logic). So now the private message instead uses the .username and .tag attributes to provide the normal userid, like so: @GenericUser#1234

While this may be a tad confusing to those using nicknames, it identifies the exact individual doing the tipping, it just might require a little digging.