### PR TITLE
Fixing Roletip sendLBC call

### DIFF
--- a/bot/modules/tipbot.js
+++ b/bot/modules/tipbot.js
@@ -273,7 +273,7 @@ function doRoleTip(message, tipper, words, helpmsg) {
     if (message.mentions.roles.first().members.first().id) {
       let userIDs = message.mentions.roles.first().members.map(member => member.user.id.replace('!', ''));
       for (let i = 0; i < userIDs; i++) {
-        sendLBC(message, tipper, userIDs[i], amount, prv);
+        sendLBC(message, tipper, userIDs[i].toString(), amount, prv);
       }
     } else {
       message.reply('Sorry, I could not find any users to tip in that role...').then(message => message.delete(5000));


### PR DESCRIPTION
Apparently despite being a supposedly smart language, JS still insists on making me convert a string of numbers from a number back to a string before _and_ inside a function call, yay aggressively dynamically typed languages.

This _should_ fix the matter now