### PR TITLE
Fixed a minor typo and forced FAQ URL to NOT embed.

### DIFF
--- a/bot/modules/tipbot.js
+++ b/bot/modules/tipbot.js
@@ -23,7 +23,7 @@ const helpmsg = {
       '**Note**: Multi tips can contain any amount of users to tip.\n\n' +
       '__**FURTHER INFORMATION**__\n\n' +
       '**Help**: `!tip help` *Get this message.\n' +
-      'Read our [Tipbot FAQ](<https://lbry.com/faq/tipbot-discord>) for a more details',
+      'Read our [Tipbot FAQ](<https://lbry.com/faq/tipbot-discord>) for more details',
     color: 1109218
   }
 };
@@ -114,7 +114,7 @@ exports.roletip = {
 
 exports.tips = {
   usage: '',
-  description: 'Lists all available tipbot commands with brief descriptions for each one.',
+  description: 'Lists all available tipbot commands with brief descriptions for each command.',
   process: async function(bot, msg, suffix) {
     msg.reply(helpmsg);
   }
@@ -285,7 +285,7 @@ function sendLBC(bot, message, tipper, recipient, amount, privacyFlag, MultiorRo
         } else {
           let tx = txLink(txId);
           let msgtail = `
-DM me with \`!tips\` for all available commands or read our Tipbot FAQ https://lbry.com/faq/tipbot-discord for more details`;
+DM me with \`!tips\` for all available commands or read our Tipbot FAQ <https://lbry.com/faq/tipbot-discord> for more details`;
           if (privacyFlag) {
             let usr = message.guild.members.find('id', recipient).user;
             let authmsg = `You have sent a private tip to @${usr.tag} with the amount of ${amount} LBC.


### PR DESCRIPTION
Fixed a minor typo and forced FAQ URL to NOT embed. 

When a user is tipped, the "read our Tipbot FAQ" URL will no longer embed.
Also fixed a minor typo "for a more details"